### PR TITLE
  商品削除機能

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -44,10 +44,11 @@ class OrdersController < ApplicationController
 
   def pay_item
     return if Rails.env.test? # テスト時は外部決済を実行しない
+
     Payjp.api_key = ENV['PAYJP_SECRET_KEY']
     Payjp::Charge.create(
-      amount:   @item.price,
-      card:     order_params[:token],
+      amount: @item.price,
+      card: order_params[:token],
       currency: 'jpy'
     )
   end

--- a/app/models/order_address.rb
+++ b/app/models/order_address.rb
@@ -13,6 +13,7 @@ class OrderAddress
 
   def save
     return false unless valid?
+
     ActiveRecord::Base.transaction do
       order = Order.create!(user_id: user_id, item_id: item_id)
       Address.create!(

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,5 +21,4 @@ class User < ApplicationRecord
   validates :password,
             format: { with: PASSWORD_FMT, message: 'は英字と数字の両方を含めてください' },
             allow_nil: true
-  
 end

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -29,22 +29,22 @@
       </span>
     </div>
 
-    <% if signed_in %>
-      <% if author %>
-        <% unless sold %>
-          <%= link_to "商品の編集", edit_item_path(@item), class: "item-red-btn" %>
-          <p class="or-text">or</p>
-          <%# 削除は未実装なのでダミー %>
-          <span class="item-destroy is-disabled" aria-disabled="true">削除</span>
-        <% end %>
-      <% else %>
-        <% unless sold %>
-          <%= link_to "購入画面に進む",
-                      item_orders_path(@item),
-                      class: "item-red-btn" %>
-        <% end %>
-      <% end %>
+    <% sold  = @item.order.present? %>
+<% owner = user_signed_in? && current_user == @item.user %>
+
+<% if user_signed_in? %>
+  <% if owner %>
+    <% unless sold %>
+      <%= link_to '商品の編集', edit_item_path(@item), class: 'item-red-btn' %>
+      <p class="or-text">or</p>
+      <%= link_to '削除', item_path(@item), data: { turbo_method: :delete }, class: 'item-destroy' %>
     <% end %>
+  <% else %>
+    <% unless sold %>
+      <%= link_to '購入画面に進む', item_orders_path(@item), class: 'item-red-btn' %>
+    <% end %>
+  <% end %>
+<% end %>
 
 
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
   
   root "items#index"
-  resources :items, only: [:index, :new, :create, :show, :edit, :update] do
+  resources :items do
     resources :orders, only: [:index, :create]
   end
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -9,6 +9,6 @@ FactoryBot.define do
     first_name            { '太郎' }
     last_name_kana        { 'ヤマダ' }
     first_name_kana       { 'タロウ' }
-    birth_date            { Date.new(2000,1,1) }
+    birth_date            { Date.new(2000, 1, 1) }
   end
 end

--- a/spec/models/order_address_spec.rb
+++ b/spec/models/order_address_spec.rb
@@ -8,15 +8,15 @@ RSpec.describe OrderAddress, type: :model do
 
   let(:base_attrs) do
     {
-      postal_code:   '123-4567',
+      postal_code: '123-4567',
       prefecture_id: 2,
-      city:          '渋谷区',
-      block:         '神南1-1-1', # schema.rbのカラム名が block なので block のまま
-      building:      'XXビル',
-      phone_number:  '0901234567', # 10桁でもOK判定用の初期値
-      token:         'tok_test_abc',
-      user_id:       buyer.id,
-      item_id:       item.id
+      city: '渋谷区',
+      block: '神南1-1-1', # schema.rbのカラム名が block なので block のまま
+      building: 'XXビル',
+      phone_number: '0901234567', # 10桁でもOK判定用の初期値
+      token: 'tok_test_abc',
+      user_id: buyer.id,
+      item_id: item.id
     }
   end
 
@@ -125,7 +125,7 @@ RSpec.describe OrderAddress, type: :model do
       end
     end
 
-        context '購入できないとき（追加のフォーマット検証）' do
+    context '購入できないとき（追加のフォーマット検証）' do
       it '都道府県がnilだと無効' do
         oa = OrderAddress.new(base_attrs.merge(prefecture_id: nil))
         expect(oa).to be_invalid
@@ -166,20 +166,20 @@ RSpec.describe OrderAddress, type: :model do
     context '保存失敗時は副作用なし' do
       it '無効なときはOrder/Addressが増えない' do
         oa = OrderAddress.new(base_attrs.merge(postal_code: '1234567')) # ハイフン無しで無効
-        expect {
+        expect do
           expect(oa.save).to eq false
-        }.to not_change(Order, :count)
-         .and not_change(Address, :count)
+        end.to not_change(Order, :count)
+          .and not_change(Address, :count)
       end
     end
 
     context '保存処理（副作用）' do
       it 'saveでOrderとAddressが作成される' do
         oa = OrderAddress.new(base_attrs)
-        expect {
+        expect do
           expect(oa.save).to eq true
-        }.to change(Order, :count).by(1)
-         .and change(Address, :count).by(1)
+        end.to change(Order, :count).by(1)
+                                    .and change(Address, :count).by(1)
 
         order   = Order.order(:created_at).last
         address = Address.order(:created_at).last


### PR DESCRIPTION
What

・商品の削除機能を実装
・ログイン済みかつ出品者本人かつ未売却のときのみ「削除」ボタン表示


Why（なぜやったか）

・出品者のみが自身の商品の削除を可能とする目的
・売却済みの改ざんを防止する目的


ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる
https://gyazo.com/fb0552aca5a7074ebb98be8bad94c576